### PR TITLE
Generate proxy record field names in camelcase

### DIFF
--- a/scripts/generateTypings.ts
+++ b/scripts/generateTypings.ts
@@ -188,7 +188,7 @@ class GenerateTypings {
       const prettyName = name.charAt(0).toUpperCase() + name.substr(1).replace(/_/g, " ");
       const description = "Returns:" in dataList ? this.turndown.turndown(dataList["Returns:"].innerHTML) : prettyName;
 
-      return { type, name, description };
+      return { type, name: camelCase(name), description };
     });
 
     return {


### PR DESCRIPTION
This PR camelizes proxy record names. E.g. `Item.tcrs_name` should become `Item.tcrsName`, which is how they are accessed in KoLmafia JS.

I could not check whether this actually works, so apologies if it fails.