### PR TITLE
Add type definitions for popular ASH scripts

### DIFF
--- a/contrib/EatDrink.ash.d.ts
+++ b/contrib/EatDrink.ash.d.ts
@@ -1,0 +1,32 @@
+/**
+ * @file Type definition for EatDrink, made by dj_d.
+ *
+ * - ASH script name: EatDrink
+ * - ASH script version: 3.2
+ * - ASH script authors: dj_d
+ *
+ * Links:
+ *  - ASH script forum thread: https://kolmafia.us/threads/eatdrink-ash-optimize-your-daily-diet-and-see-how-your-old-diet-stacks-up.1519/
+ */
+
+/**
+ * @return Net number of adventures gained
+ */
+export function eatdrink(
+  foodMax: number,
+  drinkMax: number,
+  spleenMax: number,
+  overdrink: boolean
+): number;
+
+export function eatdrink(
+  foodMax: number,
+  drinkMax: number,
+  spleenMax: number,
+  overdrink: boolean,
+  advmeat: number,
+  primemeat: number,
+  offmeat: number,
+  pullmeat: number,
+  sim: boolean
+): void;

--- a/contrib/PriceAdvisor.d.ts
+++ b/contrib/PriceAdvisor.d.ts
@@ -1,0 +1,41 @@
+/**
+ * @file Type definition for PriceAdvisor, made by aqualectrix.
+ *
+ * - ASH script name: PriceAdvisor
+ * - ASH script version: 1.62
+ * - ASH script authors: aqualectrix
+ *
+ * Links:
+ *  - ASH script forum thread: https://kolmafia.us/threads/priceadvisor-maximize-your-profits.3110/
+ */
+
+export interface PriceAdvice {
+  /** Action command that can be executed in the gCLI */
+  action: string;
+  /** Expected meat gain from the action. A floating-point number. */
+  price: number;
+}
+
+/**
+ * Calculates the most profitable advice for `item`.
+ * @param item
+ * @param considerMore
+ * @return Most profitable advice with respect to `considerMore`
+ */
+export function bestAdvice(it: Item, considerMore: boolean): PriceAdvice;
+
+/**
+ * Calculates all possible advices which have a positive profit.
+ * @param item
+ * @param considerMore
+ * @return All profitable advices for `item`, sorted from best to worst
+ */
+export function priceAdvisor(
+  it: Item,
+  considerMore: boolean
+): {[key: number]: PriceAdvice};
+
+/**
+ * Resets the internal price advice cache.
+ */
+export function clearAdviceCache(): void;

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,48 @@
+# README
+
+The `*.d.ts` files in this directory are type definitions for popular ASH scripts.
+
+## Usage
+
+Suppose you want to use Zlib in your TypeScript code. Importing Zlib will not work:
+
+```ts
+// Cannot find module 'zlib.ash' or its corresponding type declarations. (ts(2307))
+import {getvar, setvar} from "zlib.ash";
+```
+
+To allow TypeScript to locate the type definition, you must modify `tsconfig.json` in your project:
+
+```json5
+{
+  "compilerOptions": {
+    "paths": {
+      // Add this line
+      // Warning: File names are case sensitive!
+      "zlib.ash": ["./node_modules/kolmafia/contrib/zlib.ash"]
+    }
+  }
+}
+```
+
+## Adding a type definition
+
+If you want to submit a new type definition, ensure that the definition file name matches the spelling of the _ASH file name_. (e.g. `zlib.ash.d.ts` instead of `Zlib.ash.d.ts`)
+
+Use the following template as a starting point:
+
+```ts
+/**
+ * @file Type definition for <script name>, made by <original author name>.
+ *
+ * - ASH script name: <script name>
+ * - ASH script version: <version>
+ * - ASH script authors: <Comma-separated list of authors and maintainers>
+ *
+ * Links:
+ *  - ASH script forum thread: <Add URL or remove this line>
+ *  - ASH script repository: <Add URL or remove this line>
+ */
+
+// Add type definitions below and delete this comment
+```

--- a/contrib/canadv.ash.d.ts
+++ b/contrib/canadv.ash.d.ts
@@ -1,0 +1,18 @@
+/**
+ * @file Type definition for CanAdv, made by dj_d.
+ *
+ * - ASH script name: CanAdv
+ * - ASH script version: r109
+ * - ASH script authors: zarqon, Theraze
+ *
+ * Links:
+ *  - ASH script forum thread: https://kolmafia.us/threads/canadv-check-whether-you-can-adventure-at-a-given-location.2027/
+ */
+
+/**
+ * Checks if the player can adventure at `location`.
+ * @param location
+ * @param prep If `true`, will equip items, use potions, etc. to meet
+ *    requirements for visiting the location. Default is `false`
+ */
+export function canAdv(where: Location, prep?: boolean): boolean;

--- a/contrib/zlib.ash.d.ts
+++ b/contrib/zlib.ash.d.ts
@@ -1,0 +1,63 @@
+/**
+ * @file Type definition for Zlib, made by zarqon.
+ *
+ * - ASH script name: Zlib
+ * - ASH script version: r49
+ * - ASH script authors: zarqon
+ *
+ * Links:
+ *  - ASH script forum thread: https://kolmafia.us/threads/zlib-zarqons-useful-function-library.2072/
+ *  - Wiki page: https://wiki.kolmafia.us/index.php?title=Zlib
+ */
+
+export function kmail(to: string, message: string, meat: number): boolean;
+
+export function setvar(
+  varname: string,
+  defaultValue: string,
+  type:
+    | 'string'
+    | 'boolean'
+    | 'bounty'
+    | 'class'
+    | 'coinmaster'
+    | 'effect'
+    | 'element'
+    | 'familiar'
+    | 'float'
+    | 'int'
+    | 'item'
+    | 'location'
+    | 'monster'
+    | 'phylum'
+    | 'servant'
+    | 'skill'
+    | 'stat'
+    | 'thrall'
+    | 'vykea'
+): void;
+
+export function setvar(
+  varname: string,
+  defaultValue:
+    | string
+    | boolean
+    | Bounty
+    | Class
+    | Coinmaster
+    | Effect
+    | Element
+    | Familiar
+    | number
+    | Item
+    | Location
+    | Monster
+    | Phylum
+    | Servant
+    | Skill
+    | Stat
+    | Thrall
+    | Vykea
+): void;
+
+export function getvar(varname: string): string;


### PR DESCRIPTION
I've been writing type definitions for ASH scripts for a while now. It would be great to have a central repository for them, a la [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped). I thought, 'why not kolmafia-js'?